### PR TITLE
feat(ci): use cargo-llvm-cov proc-macro coverage for separate tracking

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -18,17 +18,21 @@ jobs:
         uses: taiki-e/cache-cargo-install-action@v3
         with:
           tool: cargo-llvm-cov
-      - name: Run cargo-llvm-cov for proc-macro coverage
+      - name: Run cargo-llvm-cov for macro source coverage
         run: |
           cargo clean
           cargo llvm-cov --workspace --all-features --doctests \
             --experimental-proc-macro-coverage \
             --lcov --output-path macro-source.lcov \
             --proc-macro-coverage source
+      - name: Run cargo-llvm-cov for macro expanded coverage
+        run: |
           cargo llvm-cov --workspace --all-features --doctests \
             --experimental-proc-macro-coverage \
             --lcov --output-path macro-expanded.lcov \
             --proc-macro-coverage expanded
+      - name: Run cargo-llvm-cov for library coverage
+        run: |
           cargo llvm-cov --workspace --all-features --doctests \
             --lcov --output-path lib.lcov
       - name: Upload macro source coverage to Codecov

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -20,7 +20,6 @@ jobs:
           tool: cargo-llvm-cov
       - name: Run cargo-llvm-cov for macro crate coverage
         run: |
-          cargo clean
           cargo llvm-cov -p strict-num-extended-macros \
             --all-features --doctests \
             --lcov --output-path macro-source.lcov

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -9,47 +9,51 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Cache APT packages
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: lcov
-          version: 1.0
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
           components: llvm-tools-preview
-      - name: Install grcov
-        uses: taiki-e/cache-cargo-install-action@v3
-        with:
-          tool: grcov
       - name: Install cargo-llvm-cov
         uses: taiki-e/cache-cargo-install-action@v3
         with:
           tool: cargo-llvm-cov
-      - name: Run grcov for proc-macro generator code
+      - name: Run cargo-llvm-cov for proc-macro coverage
         run: |
           cargo clean
-          CARGO_INCREMENTAL=0 RUSTFLAGS="-C instrument-coverage" cargo test --no-fail-fast
-          grcov . -s . --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing --ignore "/*" -o generator.lcov
-      - name: Run cargo-llvm-cov for generated code
-        run: |
-          cargo clean
-          cargo llvm-cov --workspace --all-features --doctests --lcov --output-path generated.lcov
-      - name: Upload generator coverage to Codecov
+          cargo llvm-cov --workspace --all-features --doctests \
+            --experimental-proc-macro-coverage \
+            --lcov --output-path macro-source.lcov \
+            --proc-macro-coverage source
+          cargo llvm-cov --workspace --all-features --doctests \
+            --experimental-proc-macro-coverage \
+            --lcov --output-path macro-expanded.lcov \
+            --proc-macro-coverage expanded
+          cargo llvm-cov --workspace --all-features --doctests \
+            --lcov --output-path lib.lcov
+      - name: Upload macro source coverage to Codecov
         uses: codecov/codecov-action@v6
         with:
-          files: ./generator.lcov
-          flags: generator
+          files: ./macro-source.lcov
+          flags: macro-source
           verbose: true
           fail_ci_if_error: true
           disable_search: true
           token: ${{ secrets.CODECOV_TOKEN }}
-      - name: Upload main coverage to Codecov
+      - name: Upload macro expanded coverage to Codecov
         uses: codecov/codecov-action@v6
         with:
-          files: ./generated.lcov
-          flags: main
+          files: ./macro-expanded.lcov
+          flags: macro-expanded
+          verbose: true
+          fail_ci_if_error: true
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload library coverage to Codecov
+        uses: codecov/codecov-action@v6
+        with:
+          files: ./lib.lcov
+          flags: lib
           verbose: true
           fail_ci_if_error: true
           disable_search: true

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -18,37 +18,22 @@ jobs:
         uses: taiki-e/cache-cargo-install-action@v3
         with:
           tool: cargo-llvm-cov
-      - name: Run cargo-llvm-cov for macro source coverage
+      - name: Run cargo-llvm-cov for macro crate coverage
         run: |
           cargo clean
-          cargo llvm-cov --workspace --all-features --doctests \
-            --experimental-proc-macro-coverage \
-            --lcov --output-path macro-source.lcov \
-            --proc-macro-coverage source
-      - name: Run cargo-llvm-cov for macro expanded coverage
-        run: |
-          cargo llvm-cov --workspace --all-features --doctests \
-            --experimental-proc-macro-coverage \
-            --lcov --output-path macro-expanded.lcov \
-            --proc-macro-coverage expanded
+          cargo llvm-cov -p strict-num-extended-macros \
+            --all-features --doctests \
+            --lcov --output-path macro-source.lcov
       - name: Run cargo-llvm-cov for library coverage
         run: |
-          cargo llvm-cov --workspace --all-features --doctests \
+          cargo llvm-cov -p strict-num-extended \
+            --all-features --doctests \
             --lcov --output-path lib.lcov
       - name: Upload macro source coverage to Codecov
         uses: codecov/codecov-action@v6
         with:
           files: ./macro-source.lcov
           flags: macro-source
-          verbose: true
-          fail_ci_if_error: true
-          disable_search: true
-          token: ${{ secrets.CODECOV_TOKEN }}
-      - name: Upload macro expanded coverage to Codecov
-        uses: codecov/codecov-action@v6
-        with:
-          files: ./macro-expanded.lcov
-          flags: macro-expanded
           verbose: true
           fail_ci_if_error: true
           disable_search: true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch CI coverage to `cargo-llvm-cov` and track macro crate and library coverage separately in Codecov. Removes `grcov` and APT `lcov` to simplify the workflow.

- New Features
  - Generate and upload LCOV reports for `strict-num-extended-macros` and `strict-num-extended` as `macro-source.lcov` and `lib.lcov` (flags: `macro-source`, `lib`).

- Refactors
  - Use `-p` to target crates and split generation/uploads per crate.
  - Remove unnecessary `cargo clean` steps.

<sup>Written for commit 0fbfd6d95dac4c212e1ead8bd1af37140ec0e3fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

